### PR TITLE
ELPP-3356 Configure gateway URL by environment

### DIFF
--- a/salt/observer/config/srv-observer-app.cfg
+++ b/salt/observer/config/srv-observer-app.cfg
@@ -10,7 +10,7 @@ allowed-hosts: *
 # no whitespace! yes, it matters! 
 allowed-hosts: .{{ salt['elife.cfg']('project.domain') }},.{{ salt['elife.cfg']('project.int_domain') }}
 {% endif %}
-api-url: https://prod--gateway.elifesciences.org
+api-url: https://{{ pillar.elife.env }}--gateway.elifesciences.org
 
 [sqs]
 queue-name: observer--{{ salt['elife.cfg']('project.instance_id') }}


### PR DESCRIPTION
It may even be able to use the `elife.internal` URL?