### PR TITLE
Safer long-running process

### DIFF
--- a/salt/observer/config/etc-init-update-listener.conf
+++ b/salt/observer/config/etc-init-update-listener.conf
@@ -5,7 +5,7 @@ respawn limit 30 30
 start on (local-filesystems and net-device-up IFACE!=lo)
 {% if pillar.elife.newrelic.enabled %}
 env NEW_RELIC_CONFIG_FILE=/srv/observer/newrelic.ini
-exec /srv/observer/venv/bin/newrelic-admin run-program ./manage.sh update_listener
+exec /srv/observer/venv/bin/newrelic-admin run-program /srv/observer/venv/bin/python src/manage.py update_listener
 {% else %}
 exec ./manage.sh update_listener
 {% endif %}

--- a/salt/observer/config/lib-systemd-system-update-listener.service
+++ b/salt/observer/config/lib-systemd-system-update-listener.service
@@ -17,7 +17,7 @@ WorkingDirectory=/srv/observer
 
 {% if pillar.elife.newrelic.enabled %}
 Environment="NEW_RELIC_CONFIG_FILE=/srv/observer/newrelic.ini"
-ExecStart=/srv/observer/venv/bin/newrelic-admin run-program ./manage.sh update_listener
+ExecStart=/srv/observer/venv/bin/newrelic-admin run-program /srv/observer/venv/bin/python src/manage.py update_listener
 {% else %}
-ExecStart=/srv/observer/manage.sh update_listener
+ExecStart=/srv/observer/venv/bin/python src/manage.py update_listener
 {% endif %}


### PR DESCRIPTION
That does not touch the virtualenv or the database schema

Moved from https://github.com/elifesciences/observer/pull/40