### PR TITLE
Feature: bumps metabase to version 0.31.2 from 0.27.2

### DIFF
--- a/salt/observer/init.sls
+++ b/salt/observer/init.sls
@@ -3,9 +3,11 @@ install-metabase:
         - name: /srv/metabase/metabase.jar
         - makedirs: True
         #- source: http://downloads.metabase.com/v0.23.1/metabase.jar
-        - source: http://downloads.metabase.com/v0.27.2/metabase.jar
+        #- source: http://downloads.metabase.com/v0.27.2/metabase.jar
         #- source_hash: md5=79c805a6c63c4d1aae5c6afe2839e667
-        - source_hash: md5=873ece005f6f7dab505212763c266aee
+        #- source_hash: md5=873ece005f6f7dab505212763c266aee
+        - source: http://downloads.metabase.com/v0.31.2/metabase.jar
+        - source_hash: f658bccad16860601bbd4eadacaeeb86
 
         - watch_in:
             - service: nginx-server-service


### PR DESCRIPTION
it's worth noting that the backup for Metabase includes the .jar file, so if you restore from a backup, you'll need to run highstate again to install the new Metabase which will automatically upgrade your installation after the service restarts.

fyi @giorgiosironi 